### PR TITLE
Capabilities and ObjectIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+* No longer auto-converts 'objectid' field to '_id' for ES queries
+### Added
+* Support to allow configured list of capabilities for feature service layers. This will allow a client to handle any
+capability they wish.
+
 ## [3.1.0] - 07-27-2021
 ### Changed
 * aggregations config has been changed to subLayers

--- a/src/model.js
+++ b/src/model.js
@@ -92,6 +92,10 @@ module.exports = function (koop) {
             }
         };
 
+        if(indexConfig.capabilities){
+            featureCollection.metadata.capabilities = indexConfig.capabilities;
+        }
+
         if (customSymbolizer) {
             featureCollection.metadata.vt = customSymbolizer.vtStyle();
         } else if (indexConfig.vectorStyle) {
@@ -138,7 +142,7 @@ module.exports = function (koop) {
             return;
         }
 
-        // logger.debug(JSON.stringify(esQuery));
+        // logger.debug(JSON.stringify(query));
         if (layerId === "0" || undefined === layerId) {
             try {
                 let mapping = await this.indexInfo.getMapping(esId, indexConfig.index, indexConfig.mapping);

--- a/src/subLayers/geoHashAggregation.js
+++ b/src/subLayers/geoHashAggregation.js
@@ -1,4 +1,3 @@
-const tilebelt = require('@mapbox/tilebelt');
 const GeoHashUtil = require('../utils/geohashUtil');
 const HitConverter = require('../utils/hitConverter');
 

--- a/src/utils/whereParser.js
+++ b/src/utils/whereParser.js
@@ -14,9 +14,9 @@ class WhereParser {
 
         // convert objectid's to the _id used by elasticsearch.
         // TODO: make the objectid column configurable (allow using other columns/attributes)
-        if (lowercaseFieldName === "objectid") {
-            return "_id";
-        }
+        // if (lowercaseFieldName === "objectid") {
+        //     return "_id";
+        // }
 
         for(let i=0; i< this.returnFields.length; i++){
             let rootFieldName = this.returnFields[i];


### PR DESCRIPTION
allow configured capabilities to be passed in. Also updates the where parser to not assume it should convert objectid to elasticsearch _id.