### PR TITLE
Use case insensitive regex to remove TIMESTAMP from where clause

### DIFF
--- a/src/utils/whereParser.js
+++ b/src/utils/whereParser.js
@@ -326,7 +326,7 @@ class WhereParser {
         let shouldArray = [];
         let mustArray = [];
         let mustNotArray = [];
-        whereClause = whereClause.replace(/timestamp '/g, " '");
+        whereClause = whereClause.replace(/timestamp '/gi, " '");
         whereClause = whereClause.replace('UPPER', '');
         let ast = sqliteParser("SELECT * FROM BLAH WHERE " + whereClause);
         let whereItem = ast.statement[0].where[0];


### PR DESCRIPTION
Minor fix to use case insensitive regex to match both lower-case "timestamp" and upper-case "TIMESTAMP" when parsing where clause.  Queries that used TIMESTAMP would previously fail SQL parsing.